### PR TITLE
Change link from gmane to mail-archive

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 TigerVNC was originally based on the (never-released) VNC 4 branch of
 <a href="http://www.tightvnc.com/">TightVNC</a>. More information
 regarding the motivation for creating this project can be found in the
-<a href="http://article.gmane.org/gmane.network.tight-vnc.general/8610/">project
+<a href="http://mid.mail-archive.com/alpine.LFD.2.00.0902271116020.25749@maggie.lkpg.cendio.se">project
 announcement</a>.
 </p>
 


### PR DESCRIPTION
Since the gmane web frontend is [currently unavailable](https://lars.ingebrigtsen.no/2016/07/28/the-end-of-gmane/), it is probably better to use some other archive of the message in question. The use of the [message id](https://en.wikipedia.org/wiki/Message-ID) should make it easy to change to a different archive if the need arises again.